### PR TITLE
Chore/make prospector compilable

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,6 +2,8 @@ project(prospector)
 
 cmake_minimum_required (VERSION 3.19)
 
+set(CMAKE_CUDA_COMPILER $CUDA_HOME/bin/nvcc)
+
 enable_language("CUDA")
 
 if(NOT DEFINED CMAKE_CUDA_STANDARD)
@@ -10,9 +12,19 @@ if(NOT DEFINED CMAKE_CUDA_STANDARD)
 endif()
 
 include_directories(${CMAKE_CUDA_TOOLKIT_INCLUDE_DIRECTORIES})
+
+# Find Boost at /usr/local/boost_1_76_0
+set(Boost_USE_STATIC_LIBS OFF)
+set(Boost_USE_MULTITHREADED ON)
+set(Boost_USE_STATIC_RUNTIME OFF)
+find_package(Boost 1.76.0)
+
+if(Boost_FOUND)
+    include_directories(${Boost_INCLUDE_DIRS})
+endif()
+
 include_directories(include)
 include_directories(lib)
-include_directories("/home/ben/boost_1_76_0")
 
 
 add_library(util "src/cas.cpp" "src/array_discovery.cpp" "src/cas_profiles.cpp" "src/crispr.cpp" "src/debug.cpp" "src/util.cpp")
@@ -24,4 +36,4 @@ set_property(TARGET prospector PROPERTY CXX_STANDARD 17)
 
 add_executable(exec "src/main.cpp")
 set_property(TARGET exec PROPERTY CXX_STANDARD 20)
-target_link_libraries(exec util prospector)
+target_link_libraries(exec util prospector ${Boost_LIBRARIES})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,17 @@ project(prospector)
 
 cmake_minimum_required (VERSION 3.19)
 
-set(CMAKE_CUDA_COMPILER $CUDA_HOME/bin/nvcc)
+set(CMAKE_CUDA_COMPILER /usr/local/cuda/bin/nvcc)
+
+# Find installed GPUs and get GPU architectures
+include(FindCUDA/select_compute_arch)
+CUDA_DETECT_INSTALLED_GPUS(INSTALLED_GPU_CCS_1)
+string(STRIP "${INSTALLED_GPU_CCS_1}" INSTALLED_GPU_CCS_2)
+string(REPLACE " " ";" INSTALLED_GPU_CCS_3 "${INSTALLED_GPU_CCS_2}")
+string(REPLACE "." "" CUDA_ARCH_LIST "${INSTALLED_GPU_CCS_3}")
+string(REPLACE "+PTX" "" CUDA_ARCH_LIST "${CUDA_ARCH_LIST}")
+
+SET(CMAKE_CUDA_ARCHITECTURES ${CUDA_ARCH_LIST})
 
 enable_language("CUDA")
 
@@ -31,9 +41,9 @@ add_library(util "src/cas.cpp" "src/array_discovery.cpp" "src/cas_profiles.cpp" 
 set_property(TARGET util PROPERTY CXX_STANDARD 20)
 
 add_library(prospector "src/prospector.cu")
-set_property(TARGET prospector PROPERTY CUDA_ARCHITECTURES 75)
 set_property(TARGET prospector PROPERTY CXX_STANDARD 17)
 
 add_executable(exec "src/main.cpp")
 set_property(TARGET exec PROPERTY CXX_STANDARD 20)
+
 target_link_libraries(exec util prospector ${Boost_LIBRARIES})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,16 +3,7 @@ project(prospector)
 cmake_minimum_required (VERSION 3.19)
 
 set(CMAKE_CUDA_COMPILER /usr/local/cuda/bin/nvcc)
-
-# Find installed GPUs and get GPU architectures
-include(FindCUDA/select_compute_arch)
-CUDA_DETECT_INSTALLED_GPUS(INSTALLED_GPU_CCS_1)
-string(STRIP "${INSTALLED_GPU_CCS_1}" INSTALLED_GPU_CCS_2)
-string(REPLACE " " ";" INSTALLED_GPU_CCS_3 "${INSTALLED_GPU_CCS_2}")
-string(REPLACE "." "" CUDA_ARCH_LIST "${INSTALLED_GPU_CCS_3}")
-string(REPLACE "+PTX" "" CUDA_ARCH_LIST "${CUDA_ARCH_LIST}")
-
-SET(CMAKE_CUDA_ARCHITECTURES ${CUDA_ARCH_LIST})
+SET(CMAKE_CUDA_ARCHITECTURES 52)
 
 enable_language("CUDA")
 
@@ -43,7 +34,13 @@ set_property(TARGET util PROPERTY CXX_STANDARD 20)
 add_library(prospector "src/prospector.cu")
 set_property(TARGET prospector PROPERTY CXX_STANDARD 17)
 
-add_executable(exec "src/main.cpp" include/config.h)
+add_executable(exec "src/main.cpp" include/config.h include/system.h)
 set_property(TARGET exec PROPERTY CXX_STANDARD 20)
 
-target_link_libraries(exec util prospector ${Boost_LIBRARIES})
+find_package(OpenMP)
+if(OpenMP_CXX_FOUND)
+    SET(OPENMP OpenMP::OpenMP_CXX)
+endif()
+
+
+target_link_libraries(exec util prospector ${Boost_LIBRARIES} ${OPENMP})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -37,13 +37,13 @@ include_directories(include)
 include_directories(lib)
 
 
-add_library(util "src/cas.cpp" "src/array_discovery.cpp" "src/cas_profiles.cpp" "src/crispr.cpp" "src/debug.cpp" "src/util.cpp")
+add_library(util "src/cas.cpp" "src/array_discovery.cpp" "src/cas_profiles.cpp" "src/crispr.cpp" "src/debug.cpp" "src/util.cpp" src/config.cpp)
 set_property(TARGET util PROPERTY CXX_STANDARD 20)
 
 add_library(prospector "src/prospector.cu")
 set_property(TARGET prospector PROPERTY CXX_STANDARD 17)
 
-add_executable(exec "src/main.cpp")
+add_executable(exec "src/main.cpp" include/config.h)
 set_property(TARGET exec PROPERTY CXX_STANDARD 20)
 
 target_link_libraries(exec util prospector ${Boost_LIBRARIES})

--- a/include/config.h
+++ b/include/config.h
@@ -20,6 +20,8 @@ namespace Config
 
     extern int crispr_proximal_search;
     extern int skip_serialisation;
+    extern int cas_only;
+    extern int dump_indices;
 
     void parse_program_args(int argc, char *argv[]);
 }

--- a/include/config.h
+++ b/include/config.h
@@ -1,0 +1,28 @@
+//
+// Created by zach on 27/07/22.
+//
+
+#ifndef PROSPECTOR_CONFIG_H
+#define PROSPECTOR_CONFIG_H
+
+#include "path.h"
+
+namespace Config
+{
+    extern const std::filesystem::path default_path_output;
+    extern std::filesystem::path path_output;
+    extern std::filesystem::path path_results;
+    extern std::filesystem::path path_bin_pro;
+
+    extern std::filesystem::path path_map_dom;
+    extern std::filesystem::path path_genome;
+    extern std::filesystem::path path_cas_profiles;
+
+    extern int crispr_proximal_search;
+    extern int skip_serialisation;
+
+    void parse_program_args(int argc, char *argv[]);
+}
+
+
+#endif //PROSPECTOR_CONFIG_H

--- a/include/system.h
+++ b/include/system.h
@@ -1,0 +1,8 @@
+//
+// Created by zach on 2/08/22.
+//
+
+#ifndef PROSPECTOR_SYSTEM_H
+#define PROSPECTOR_SYSTEM_H
+
+#endif //PROSPECTOR_SYSTEM_H

--- a/include/system.h
+++ b/include/system.h
@@ -5,4 +5,74 @@
 #ifndef PROSPECTOR_SYSTEM_H
 #define PROSPECTOR_SYSTEM_H
 
+#include "locus.h"
+#include "stdafx.h"
+
+struct System
+{
+    vector<Locus*> loci;
+    string type;
+
+    ull crispr_count()
+    {
+        ull count = 0;
+        for (Locus* l : loci)
+        {
+            if (l->is_crispr())
+                count++;
+        }
+        return count;
+    }
+
+    ull cas_count()
+    {
+        ull count = 0;
+        for (Locus* l : loci)
+        {
+            if (!l->is_crispr())
+                count++;
+        }
+        return count;
+    }
+
+    void sort_loci()
+    {
+        sort(this->loci.begin(), this->loci.end(), [](Locus* a, Locus* b) { return a->get_start() - b->get_start(); });
+    }
+
+    ull get_start()
+    {
+        Locus* first = this->loci[0];
+        return first->get_start();
+    }
+
+    ull get_final()
+    {
+        Locus* last = this->loci[this->loci.size()-1];
+        return last->get_final();
+    }
+
+    string to_string_summary()
+    {
+        std::ostringstream out;
+        for (Locus* l : this->loci)
+            out << l->to_string_summary() << endl;
+        return out.str();
+    }
+
+    string to_string_debug()
+    {
+        std::ostringstream out;
+        for (Locus* l : this->loci)
+            out << l->to_string_debug() << endl;
+        return out.str();
+    }
+
+    bool legitimate_system()
+    {
+        return this->cas_count() >= 2;
+    }
+
+};
+
 #endif //PROSPECTOR_SYSTEM_H

--- a/include/util.h
+++ b/include/util.h
@@ -229,5 +229,5 @@ namespace Util
 
 	vector<kmer> encode_amino_kmers(vector<string> kmers, ull k);
 
-    //map<string, string> load_genomes(string dir);
+    void assert_file(std::filesystem::path path);
 }

--- a/src/array_discovery.cpp
+++ b/src/array_discovery.cpp
@@ -72,7 +72,7 @@ vector<Crispr*> prospector_main(string& genome)
             vector<ull> proximals{ query };
             ull target = query + k + Prospector::spacer_min;
 
-            while (++target - ( proximals[proximals.size()-1] + k) <= Prospector::spacer_max && target + k < genome.size())
+            while (++target - (proximals[proximals.size()-1] + k) <= Prospector::spacer_max && target + k < genome.size())
             {
                 
                 //auto diff = Util::difference_cpu(encoding.h[query], encoding.h[target]);
@@ -126,6 +126,7 @@ vector<Crispr*> prospector_main(string& genome)
                 all_crisprs.push_back(crispr);
             }
         }
+
     }
 
     Prospector::free_encoding(encoding);

--- a/src/cas.cpp
+++ b/src/cas.cpp
@@ -189,22 +189,25 @@ vector<Fragment*> Cas::cas(vector<CasProfile*>& profiles, vector<Translation*>& 
 
             // dump index to a file for analysis
             string file_name = Config::path_output / fmt::format("index_dump/{}_{}_{}_{}_{}_{}", CasProfileUtil::domain_table_fetch(profile->identifier), profile->identifier, t->genome_start, t->genome_final, translation_index, index.size());
-            std::ofstream out(file_name);
-            for (ull index_location : index)
-            {
-                out << index_location << "\t" << t->genome_start + index_location << endl;
+
+            if (Config::dump_indices) {
+                std::ofstream out(file_name);
+                for (ull index_location : index)
+                {
+                    out << index_location << "\t" << t->genome_start + index_location << endl;
+                }
+                out.close();
             }
-            out.close();
 
             vector<vector<ull>> clusters = cluster_index(index);
             if (!good_clusters(clusters))
             {
                 continue;
             }
-            else
+            else if (Config::dump_indices)
             {
                 fmt::print("accepted {}\n", file_name);
-    
+
                 string file_name_clust = fmt::format("{}.clust", file_name);
                 std::ofstream out(file_name_clust);
                 for (vector<ull> clust : clusters)
@@ -239,7 +242,6 @@ vector<Fragment*> Cas::cas(vector<CasProfile*>& profiles, vector<Translation*>& 
             if (f->genome_begin < 0)
             {
                 std::exit(1);
-                printf("break\n");
             }
 
             // if (f->repetition_problem())
@@ -401,7 +403,6 @@ vector <Translation*> Cas::get_sixframe(const string& genome, ull genome_start, 
 
     return sixframe;
 }
-
 
 vector<Translation*> Cas::crispr_proximal_translations(const string& genome, vector<Crispr*>& crisprs)
 {

--- a/src/cas.cpp
+++ b/src/cas.cpp
@@ -1,4 +1,5 @@
 #include "cas.h"
+#include "config.h"
 
 static unordered_set<string> alternate_starts_pos { "GTG", "TTG" };
 static unordered_set<string> alternate_starts_neg { "CAC", "CAA" };
@@ -166,10 +167,9 @@ vector<Fragment*> Cas::cas(vector<CasProfile*>& profiles, vector<Translation*>& 
 
     vector<Fragment*> fragments;
 
-    // #pragma omp parallel for
-    for (signed long p = 0; p < profiles.size(); p++)
+    #pragma omp parallel for
+    for (auto profile : profiles)
     {
-        CasProfile* profile = profiles[p];
         ui translation_index = -1;
         for (Translation* t : translations)
         {
@@ -188,17 +188,13 @@ vector<Fragment*> Cas::cas(vector<CasProfile*>& profiles, vector<Translation*>& 
                 continue;
 
             // dump index to a file for analysis
-            string file_name = fmt::format("/media/ben/temp/crispr_lfs/index_dump/{}_{}_{}_{}_{}_{}", CasProfileUtil::domain_table_fetch(profile->identifier), profile->identifier, t->genome_start, t->genome_final, translation_index, index.size());
+            string file_name = Config::path_output / fmt::format("index_dump/{}_{}_{}_{}_{}_{}", CasProfileUtil::domain_table_fetch(profile->identifier), profile->identifier, t->genome_start, t->genome_final, translation_index, index.size());
             std::ofstream out(file_name);
             for (ull index_location : index)
             {
                 out << index_location << "\t" << t->genome_start + index_location << endl;
             }
             out.close();
-
-            // std::ofstream out("/home/ben/hmm/temp_fasta.txt");
-            // out << fasta;
-            // out.close();
 
             vector<vector<ull>> clusters = cluster_index(index);
             if (!good_clusters(clusters))
@@ -207,10 +203,8 @@ vector<Fragment*> Cas::cas(vector<CasProfile*>& profiles, vector<Translation*>& 
             }
             else
             {
-
                 fmt::print("accepted {}\n", file_name);
     
-                // string file_name = fmt::format("/home/ben/index_dump/{}_{}_{}_{}_clust.txt", profile->identifier, t->genome_start, translation_index++, index.size());
                 string file_name_clust = fmt::format("{}.clust", file_name);
                 std::ofstream out(file_name_clust);
                 for (vector<ull> clust : clusters)

--- a/src/cas_profiles.cpp
+++ b/src/cas_profiles.cpp
@@ -128,28 +128,6 @@ CasProfile* profile_factory(string id, vector<string> sequences, ull k)
 	return profile;
 }
 
-
-//vector<string> get_seqs_pfam(std::filesystem::path dir)
-//{
-//	aisdgad
-//}
-//
-//vector<string> get_seqs_cog(std::filesystem::path dir)
-//{
-//	adpaiydad
-//}
-//
-//vector<string> get_seqs_tigrfam(std::filesystem::path dir)
-//{
-//	daigdad;
-//}
-//
-//vector<string> get_seqs_makarova(std::filesystem::path dir)
-//{
-//	asgdada;
-//}
-
-
 vector<CasProfile*> generate_pfams(std::filesystem::path dir)
 {
 	// ifstream input(pfam_full);

--- a/src/cas_profiles.cpp
+++ b/src/cas_profiles.cpp
@@ -1,5 +1,6 @@
 #include "cas_profiles.h"
 #include "path.h"
+#include "config.h"
 
 static std::map<string, string> domain_map;
 
@@ -128,25 +129,25 @@ CasProfile* profile_factory(string id, vector<string> sequences, ull k)
 }
 
 
-vector<string> get_seqs_pfam(std::filesystem::path dir)
-{
-	aisdgad
-}
-
-vector<string> get_seqs_cog(std::filesystem::path dir)
-{
-	adpaiydad
-}
-
-vector<string> get_seqs_tigrfam(std::filesystem::path dir)
-{
-	daigdad;
-}
-
-vector<string> get_seqs_makarova(std::filesystem::path dir)
-{
-	asgdada;
-}
+//vector<string> get_seqs_pfam(std::filesystem::path dir)
+//{
+//	aisdgad
+//}
+//
+//vector<string> get_seqs_cog(std::filesystem::path dir)
+//{
+//	adpaiydad
+//}
+//
+//vector<string> get_seqs_tigrfam(std::filesystem::path dir)
+//{
+//	daigdad;
+//}
+//
+//vector<string> get_seqs_makarova(std::filesystem::path dir)
+//{
+//	asgdada;
+//}
 
 
 vector<CasProfile*> generate_pfams(std::filesystem::path dir)
@@ -325,15 +326,6 @@ vector<CasProfile*> generate_cogs(std::filesystem::path cog_dir)
 	return generate_from_fasta(cog_dir);
 }
 
-// std::filesystem::path path_bin_pro = "/home/ben/crispr/prospector-data/bin_pro/"; // duplicated in main
-
-
-std::filesystem::path makarova_dir = "/home/ben/crispr/prospector-data/raw_pro/makarova/";
-// std::filesystem::path pfam_full = data_root / "seed/Pfam-A.full/Pfam-A.full";
-std::filesystem::path pfam_dir = "/home/ben/crispr/prospector-data/raw_pro/PFAMS/";
-// std::filesystem::path tigrfam_dir = data_root / "seed/TIGRFAMs_14.0_SEED";
-std::filesystem::path cog_dir = "/home/ben/crispr/prospector-data/raw_pro/COG/";
-
 void CasProfileUtil::serialize(std::filesystem::path path_bin_pro)
 {	
 	auto serialize_profile = [&](CasProfile* profile) {
@@ -342,14 +334,6 @@ void CasProfileUtil::serialize(std::filesystem::path path_bin_pro)
 		profile->hash_table.dump(archive);
 	};
 
-
-	// auto profiles_makarova = generate_from_fasta(makarova_dir);
-	auto profiles_pfam = generate_pfams(pfam_dir);
-	// auto profiles_tigrfams = generate_tigrfams(tigrfam_dir);
-	auto profiles_cog = generate_cogs(cog_dir);
-
-	// std::for_each(profiles_makarova.begin(), profiles_makarova.end(), serialize_profile);
-	std::for_each(profiles_pfam.begin(), profiles_pfam.end(), serialize_profile);
-	// std::for_each(profiles_tigrfams.begin(), profiles_tigrfams.end(), serialize_profile);
-	std::for_each(profiles_cog.begin(), profiles_cog.end(), serialize_profile);
+	auto profiles = generate_from_fasta(Config::path_cas_profiles);
+	std::for_each(profiles.begin(), profiles.end(), serialize_profile);
 }

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -1,0 +1,95 @@
+//
+// Created by zach on 27/07/22.
+//
+
+#include "config.h"
+#include "util.h"
+#include <getopt.h>
+#include "fmt/format.h"
+
+namespace Config
+{
+    const std::filesystem::path default_path_output = "./prospector_output";
+    std::filesystem::path path_output;
+    std::filesystem::path path_results;
+    std::filesystem::path path_bin_pro;
+    std::filesystem::path path_map_dom;
+    std::filesystem::path path_genome;
+    std::filesystem::path path_cas_profiles;
+
+    int crispr_proximal_search = 0;
+    int skip_serialisation = 0;
+
+    /**
+     * Program Arguments
+     * [REQUIRED] --prof=/path/to/cas_profiles/     : Path to directory containing Cas profiles for Cas detection
+     * [REQUIRED] --domMap=/path/to/domain_map.tsv  : Path to domain map for Cas detection
+     * [REQUIRED] --genome=/path/to/genome_folder/  : Path to folder containing genomes for analysis
+     * [OPTIONAL] --out=/path/to/output_folder/     : Path to folder where all Prospector output will be stored, defaults to ./prospector_output/
+     * [OPTIONAL] --skipSer                         : skip serialisation of profiles
+     * [OPTIONAL] --proxSearch                      : Use the CRISPR Proximal Search method for finding Cas genes
+     */
+    static struct option long_options[] = {
+            {"prof", required_argument, nullptr,'p' },
+            {"domMap", required_argument,nullptr,'d' },
+            {"genome", required_argument,nullptr,'g' },
+            {"out", required_argument,nullptr,'o' },
+            {"skipSer", no_argument, &skip_serialisation,1},
+            {"proxSearch", no_argument, &crispr_proximal_search,1 },
+            {0, 0, 0,0 },
+    };
+}
+
+
+void print_help_message()
+{
+    fmt::print("-- prospector command line arguments --\n");
+    fmt::print("[REQUIRED] --prof=/path/to/cas_profiles/     : Path to directory containing Cas profiles for Cas detection\n"
+               "[REQUIRED] --domMap=/path/to/domain_map.tsv  : Path to domain map for Cas detection\n"
+               "[REQUIRED] --genome=/path/to/genome_folder/  : Path to folder containing genomes for analysis\n"
+               "[OPTIONAL] --out=/path/to/output_folder/     : Path to folder where all Prospector output will be stored, defaults to ./prospector_output/\n"
+               "[OPTIONAL] --skipSer                         : skip serialisation of profiles\n"
+               "[OPTIONAL] --proxSearch                      : Use the CRISPR Proximal Search method for finding Cas genes\n");
+}
+
+void Config::parse_program_args(int argc, char *argv[])
+{
+    int opt;
+    int long_index = 0;
+    while ((opt = getopt_long(argc, argv,"h", long_options, &long_index )) != -1) {
+        switch (opt) {
+            case 'h':
+                print_help_message();
+                exit(0);
+                break;
+            case 'p' :
+                Config::path_cas_profiles = optarg;
+                break;
+            case 'd' :
+                Config::path_map_dom = optarg;
+                break;
+            case 'g' :
+                Config::path_genome = optarg;
+                break;
+            case 'o' :
+                Config::path_output = optarg;
+                break;
+            default:
+                break;
+        }
+    }
+
+    Util::assert_file(Config::path_map_dom);
+    Util::assert_file(Config::path_genome);
+    Util::assert_file(Config::path_cas_profiles);
+
+    // Output path is optional
+    if (Config::path_output.empty()) Config::path_output = Config::default_path_output;
+    Config::path_results = Config::path_output / "results";
+    Config::path_bin_pro = Config::path_output / "serialised_profiles";
+
+    // Create dirs in case they don't exist yet
+    std::filesystem::create_directory(Config::path_output);
+    std::filesystem::create_directory(Config::path_results);
+    std::filesystem::create_directory(Config::path_bin_pro);
+}

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -19,6 +19,8 @@ namespace Config
 
     int crispr_proximal_search = 0;
     int skip_serialisation = 0;
+    int cas_only = 0;
+    int dump_indices = 0;
 
     /**
      * Program Arguments
@@ -28,6 +30,8 @@ namespace Config
      * [OPTIONAL] --out=/path/to/output_folder/     : Path to folder where all Prospector output will be stored, defaults to ./prospector_output/
      * [OPTIONAL] --skipSer                         : skip serialisation of profiles
      * [OPTIONAL] --proxSearch                      : Use the CRISPR Proximal Search method for finding Cas genes
+     * [OPTIONAL] --casOnly                         : Only perform Cas detection, skipping CRISPR detection
+     * [OPTIONAL] --dumpIndices                     : Dump each Cas detection index to file, in the output folder prospector_output/index_dump/
      */
     static struct option long_options[] = {
             {"prof", required_argument, nullptr,'p' },
@@ -36,6 +40,8 @@ namespace Config
             {"out", required_argument,nullptr,'o' },
             {"skipSer", no_argument, &skip_serialisation,1},
             {"proxSearch", no_argument, &crispr_proximal_search,1 },
+            {"casOnly", no_argument, &cas_only,1 },
+            {"dumpIndices", no_argument, &dump_indices,1 },
             {0, 0, 0,0 },
     };
 }
@@ -49,7 +55,9 @@ void print_help_message()
                "[REQUIRED] --genome=/path/to/genome_folder/  : Path to folder containing genomes for analysis\n"
                "[OPTIONAL] --out=/path/to/output_folder/     : Path to folder where all Prospector output will be stored, defaults to ./prospector_output/\n"
                "[OPTIONAL] --skipSer                         : skip serialisation of profiles\n"
-               "[OPTIONAL] --proxSearch                      : Use the CRISPR Proximal Search method for finding Cas genes\n");
+               "[OPTIONAL] --proxSearch                      : Use the CRISPR Proximal Search method for finding Cas genes\n"
+               "[OPTIONAL] --casOnly                         : Only perform Cas detection, skipping CRISPR detection\n"
+               "[OPTIONAL] --dumpIndices                     : Dump each Cas detection index to file, in the output folder prospector_output/index_dump/\n");
 }
 
 void Config::parse_program_args(int argc, char *argv[])
@@ -61,7 +69,6 @@ void Config::parse_program_args(int argc, char *argv[])
             case 'h':
                 print_help_message();
                 exit(0);
-                break;
             case 'p' :
                 Config::path_cas_profiles = optarg;
                 break;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -9,232 +9,7 @@
 #include "path.h"
 #include <boost/algorithm/string.hpp>
 #include "config.h"
-
-// // hardcoded against cas1 for now
-// vector<ui> hammer(vector<Fragment*> fragments) {
-    
-//     // runtime:
-//     // - write candidate sequences to file
-//     // - system call of hmmscan
-//     // - parse results
-//     // - make decisions based on results
-
-//     vector<string> seqs;
-//     for (Fragment* fragment : fragments) {
-//         seqs.push_back(fragment->protein_sequence);
-//     } 
-
-//     string fasta = Util::seqs_to_fasta(seqs);
-
-//     // write candidate sequence to file
-//     std::ofstream out("/home/ben/crispr/hmm/candidates_cas1.txt");
-//     out << fasta;
-//     out.close();
-
-//     // system call of hmmscan
-//     string call = "hmmscan --tblout tbloutty.txt /home/ben/crispr/hmm/Cas_Cas1.hmm /home/ben/crispr/hmm/candidates_cas1.txt > /dev/null";
-//     system(call.c_str());
-
-//     // parse tblout
-//     std::ifstream infile("tbloutty.txt");    
-//     string line;
-//     vector<ui> acceptable_indices;
-
-//     while (std::getline(infile, line))
-//     {
-//         // fmt::print("line: {}\n", line);
-//         if (line.starts_with("#"))
-//             continue;
-
-//         vector<string> parse_result = Util::parse(line, " ");
-//         string query_name = parse_result[2];
-//         double score = std::stod(parse_result[5]);
-//         fmt::print("{} {}\n", query_name, score);
-//         acceptable_indices.push_back(std::stoi(query_name));
-//     }
-
-//     for (ui ting : acceptable_indices)
-//     {
-//         fmt::print("{}\n", ting);
-//     }
-
-//     return acceptable_indices;
-// }
-
-// vector<Fragment*> acceptable_indices_filter_methodology(vector<Fragment*> raw_fragments)
-// {
-//     // perform an analysis here of the fragments (either here or multifragments, not sure yet, but let's focus on proof of concept first)
-//     // let's focus just on cas1 for now
-//     vector<ui> acceptable_indices = hammer(raw_fragments);
-
-//     fmt::print("fasta enumeration of raw fragments:\n");
-//     for (ui i = 0; i < raw_fragments.size(); i++) {
-//         fmt::print("{}\n", i);
-//     }
-
-//     fmt::print("we now have acceptable indices\n");
-//     for (ui index : acceptable_indices) {
-//         fmt::print("{}\n", index);
-//     }
-
-//     vector<Fragment*> fragments;
-//     for (ui i = 0; i < raw_fragments.size(); i++) {
-//         if (Util::contains(acceptable_indices, i))
-//             fragments.push_back(raw_fragments[i]);
-//     }
-
-//     return fragments;
-// }
-
-
-
-//map<string, System*> system_map;
-//for (Fragment* f : fragments)
-//{
-//    if (!f->is_gene())
-//    {
-//        continue;
-//    }
-
-//    string id = f->reference_crispr->identifier_string();
-//    if (system_map.contains(id))
-//    {
-//        system_map[id]->fragments.push_back(f);
-//        continue;
-//    }
-
-//    System* system = new System;
-//    system->crispr = f->reference_crispr;
-//    system->fragments.push_back(f);
-//    system_map[id] = system;
-//}
-
-//vector<System*> systems;
-
-//for (map<string, System*>::iterator i = system_map.begin(); i != system_map.end(); i++)
-//{
-//    systems.push_back(i->second);
-//}
-
-//for (System* s : systems)
-//{
-//    s->type = resolve_type(s->fragments);
-//}
-
-//std::sort(systems.begin(), systems.end(), [](System* a, System* b) {return a->get_start() - b->get_start(); });
-//for (System* s : systems)
-    //out_gene << s->to_string();
-
-
-//std::map<string, std::set<string>> load_type_table(std::filesystem::path path)
-//{
-//    std::map<string, std::set<string>> type_table;
-//
-//    std::ifstream table(path);
-//
-//    if (!table)
-//    {
-//        throw runtime_error(path.string());
-//    }
-//
-//    string line;
-//    while (getline(table, line))
-//    {
-//        auto split = Util::parse(line, "\t");
-//        auto type = split[0];
-//        auto required = split[1];
-//        auto additional_any = split[2];
-//        
-//        std::set<string> genes;
-//
-//        for (string gene : Util::parse(, ","))
-//            genes.insert(gene);
-//
-//        type_table[links] = genes;
-//    }
-//}
-
-//string resolve_type(vector<Fragment*> fragments)
-//{
-//    return "N";
-//    for (Fragment* f : fragments)
-//    {
-//        string r = CasProfileUtil::domain_table_fetch(f->reference_profile->identifier);
-//        for (const auto& [a, b] : type_table)
-//            if (b.contains(r))
-//                return a;
-//    }
-//    return "N";
-//}
-
-
-struct System
-{
-    vector<Locus*> loci;
-    string type;
-
-    ull crispr_count()
-    {
-        ull count = 0;
-        for (Locus* l : loci)
-        {
-            if (l->is_crispr())
-                count++;
-        }
-        return count;
-    }
-
-    ull cas_count()
-    {
-        ull count = 0;
-        for (Locus* l : loci)
-        {
-            if (!l->is_crispr())
-                count++;
-        }
-        return count;
-    }
-
-    void sort_loci()
-    {
-        std::sort(this->loci.begin(), this->loci.end(), [](Locus* a, Locus* b) { return a->get_start() - b->get_start(); });
-    }
-
-    ull get_start()
-    {
-        Locus* first = this->loci[0];
-        return first->get_start();
-    }
-
-    ull get_final()
-    {
-        Locus* last = this->loci[this->loci.size()-1];
-        return last->get_final();
-    }
-
-    string to_string_summary()
-    {
-        std::ostringstream out;
-        for (Locus* l : this->loci)
-            out << l->to_string_summary() << endl;
-        return out.str();        
-    }
-
-    string to_string_debug()
-    {
-        std::ostringstream out;
-        for (Locus* l : this->loci)
-            out << l->to_string_debug() << endl;
-        return out.str();        
-    }
-
-    bool legitimate_system()
-    {
-        return this->cas_count() >= 2;
-    }
-
-};
-
+#include "system.h"
 
 vector<MultiFragment*> gen_multifragments(vector<Fragment*> fragments)
 {
@@ -249,10 +24,6 @@ vector<MultiFragment*> gen_multifragments(vector<Fragment*> fragments)
 
         for (ui j = i + 1; j < fragments.size(); j++)
         {
-            //fmt::print("multifragment comparison {}\n", j);
-            //if (fragments[i]->expanded_genome_begin == fragments[j]->expanded_genome_begin &&
-                //fragments[i]->expanded_genome_final == fragments[j]->expanded_genome_final)
-
             bool any_overlap = Util::any_overlap(fragments[i]->genome_begin, fragments[i]->genome_final,
                                                 fragments[j]->genome_begin, fragments[j]->genome_final);
 
@@ -303,7 +74,6 @@ vector<System*> gen_systems(vector<Locus*> loci)
     for (System* s : systems)
     {
         if (s->legitimate_system())
-        // if (true)
         {
             filtered_systems.push_back(s);
         }
@@ -314,166 +84,6 @@ vector<System*> gen_systems(vector<Locus*> loci)
     }
 
     return filtered_systems;
-}
-
-vector<string> get_all_hmm_files()
-{
-    vector<string> paths;
-
-    // step 1: iterate over the dir:
-    std::filesystem::path directory = "/home/ben/crispr/prospector-data/bin_hmm_makarova";
-
-    // does the split[0] of the stem match the cas_type in a case insensitive way?
-    for (const auto& entry : std::filesystem::directory_iterator(directory))
-	{
-		string filename = entry.path().filename().string();
-        vector<string> extensions = Util::parse(filename, ".");
-        string last_extension = extensions[extensions.size()-1];
-        
-        if (last_extension != "hmm")
-            continue;
-
-        string cas_type_of_file = Util::parse(filename, "_")[0];
-        paths.push_back(entry.path().string());
-    }
-    return paths;
-}
-
-vector<string> get_hmm_files(string cas_type)
-{
-    vector<string> paths;
-
-    // step 1: iterate over the dir:
-    std::filesystem::path directory = "/home/ben/crispr/prospector-data/bin_hmm_makarova";
-
-    // does the split[0] of the stem match the cas_type in a case insensitive way?
-    for (const auto& entry : std::filesystem::directory_iterator(directory))
-	{
-		string filename = entry.path().filename().string();
-        vector<string> extensions = Util::parse(filename, ".");
-        string last_extension = extensions[extensions.size()-1];
-        
-        if (last_extension != "hmm")
-            continue;
-
-        string cas_type_of_file = Util::parse(filename, "_")[0];
-        if (boost::iequals(cas_type_of_file, cas_type))
-        {
-            paths.push_back(entry.path().string());
-        }
-    }
-    return paths;
-}
-
-string get_hmm_file(string hmm_identifier)
-{
-    fmt::print("seeking HMM file with identifier: {}\n", hmm_identifier);
-    return fmt::format("/home/ben/crispr/hmm/hmm_files/{}.HMM", hmm_identifier);
-}
-
-bool have_hmm_file(string hmm_file)
-{
-    bool exists = std::filesystem::exists(hmm_file);
-    if (!exists)
-    {
-        fmt::print("does NOT exist: {}\n", hmm_file);
-    }
-    return exists;
-}
-
-bool singleton_hammer(string& singleton_seq, string hmm_file)
-{
-    if (!have_hmm_file(hmm_file))
-    {
-        throw new exception();
-    }
-
-
-    vector<string> singleton_vec;
-    singleton_vec.push_back(singleton_seq);
-    string fasta = Util::seqs_to_fasta(singleton_vec);
-
-    std::filesystem::path temp_fasta_file = "/media/ben/temp/crispr_lfs/temp_fasta.txt";
-
-    // write candidate sequence to file
-    std::ofstream out(temp_fasta_file.string());
-    out << fasta;
-    out.close();
-
-    string call = fmt::format("hmmscan --cpu 10 --tblout tbloutty.txt {} {} > /dev/null", hmm_file, temp_fasta_file.string());
-    system(call.c_str());
-
-     // parse tblout
-    std::ifstream infile("tbloutty.txt");    
-    string line;
-    vector<ui> acceptable_indices;
-
-    while (std::getline(infile, line))
-    {
-        // fmt::print("line: {}\n", line);
-        if (line.starts_with("#"))
-            continue;
-
-        vector<string> parse_result = Util::parse(line, " ");
-        string query_name = parse_result[2];
-        double score = std::stod(parse_result[5]);
-        fmt::print("{} {}\n", query_name, score);
-        acceptable_indices.push_back(std::stoi(query_name));
-    }
-
-    // return true;
-    assert(acceptable_indices.size() <= 1);
-    return acceptable_indices.size() > 0;
-}
-
-// bool singleton_hammer(Fragment* fragment) {
-//     string hmm_file;
-    
-//     // attempt an exact match
-//     hmm_file = get_hmm_file(fragment->reference_profile->identifier);
-//     if (!have_hmm_file(hmm_file)) {
-//         // exact match could be found, so this is probably like a COG profile. In which case we get the profile's domain and then we find a suitable HMM for that domain.
-//     }
-
-//     return singleton_hammer(fragment->protein_sequence, hmm_file);
-// }
-
-bool multimatch_hammer(Fragment* fragment) {
-    string cas_type_of_fragment = CasProfileUtil::domain_table_fetch(fragment->reference_profile->identifier);
-    vector<string> hmm_files = get_hmm_files(cas_type_of_fragment);
-
-    for (string hmm_file : hmm_files) {
-        if (singleton_hammer(fragment->protein_sequence, hmm_file)) {
-            return true;
-        }
-    }
-    return false;
-}
-
-// vector<Fragment*> individuated_singleton_methodology(vector<Fragment*> raw_fragments) {
-//     vector<Fragment*> fragments;
-//     for (Fragment* fragment : raw_fragments) {
-//         if (singleton_hammer(fragment)) {
-//             fragments.push_back(fragment);
-//         }
-//         else {
-//             fmt::print("rejecting {} {} {} {} on the basis of hammer\n", fragment->reference_profile->identifier, CasProfileUtil::domain_table_fetch(fragment->reference_profile->identifier), fragment->expanded_genome_begin, fragment->expanded_genome_final);
-//         }
-//     }
-//     return fragments;
-// }
-
-vector<Fragment*> multimatch_singleton_methodology(vector<Fragment*> raw_fragments) {
-    vector<Fragment*> fragments;
-    for (Fragment* fragment : raw_fragments) {
-        if (multimatch_hammer(fragment)) {
-            fragments.push_back(fragment);
-        }
-        else {
-            fmt::print("rejecting {} {} {} {} on the basis of hammer\n", fragment->reference_profile->identifier, CasProfileUtil::domain_table_fetch(fragment->reference_profile->identifier), fragment->expanded_genome_begin, fragment->expanded_genome_final);
-        }
-    }
-    return fragments;
 }
 
 void prospect_genome(vector<CasProfile*>& profiles, std::filesystem::path genome_path)
@@ -489,27 +99,26 @@ void prospect_genome(vector<CasProfile*>& profiles, std::filesystem::path genome
 
     string genome = Util::load_genome(genome_path);
 
-    vector<Crispr*> crisprs = Array::get_crisprs(genome);
-    vector<Translation*> translations = Config::crispr_proximal_search ? Cas::crispr_proximal_translations(genome, crisprs) : Cas::get_sixframe(genome, 0, genome.length()-1);
-    vector<Fragment*> raw_fragments = Cas::cas(profiles, translations, genome);
+    vector<Translation*> translations;
+    vector<Crispr*> crisprs;
 
-    out_gene_debug << fmt::format("BEGIN raw fragments\n");
-    for (Fragment* f : raw_fragments)
-    {
-        out_gene_debug << f->to_string_debug() << endl;   
+    if (Config::cas_only) {
+        translations = Cas::get_sixframe(genome, 0, genome.length()-1);
+    } else {
+        crisprs = Array::get_crisprs(genome);
+        translations = Config::crispr_proximal_search ? Cas::crispr_proximal_translations(genome, crisprs) : Cas::get_sixframe(genome, 0, genome.length()-1);
     }
-    out_gene_debug << fmt::format("END raw fragments\n");
 
-//    vector<Fragment*> fragments = multimatch_singleton_methodology(raw_fragments);
-//    vector<MultiFragment*> multifragments = gen_multifragments(fragments);
+    vector<Fragment*> fragments = Cas::cas(profiles, translations, genome);
+    vector<MultiFragment*> multifragments = gen_multifragments(fragments);
   
     std::vector<Locus*> loci;
 
     for (Crispr* c : crisprs)
         loci.push_back(c);
 
-//    for (MultiFragment* f : multifragments)
-//        loci.push_back(f);
+    for (MultiFragment* f : multifragments)
+        loci.push_back(f);
 
     std::sort(loci.begin(), loci.end(), [](Locus* a, Locus* b) { return a->get_start() < b->get_start(); });
 
@@ -518,12 +127,12 @@ void prospect_genome(vector<CasProfile*>& profiles, std::filesystem::path genome
     for (System* system : systems)
     {
         out_gene << system->to_string_summary();
-         out_gene_debug << system->to_string_debug() << endl;
+        out_gene_debug << system->to_string_debug() << endl;
     }
 
     for (Crispr* c : crisprs) delete c;
     for (Translation* t : translations) delete t;
-//    for (MultiFragment* m : multifragments) delete m;
+    for (MultiFragment* m : multifragments) delete m;
     for (System* s : systems) delete s;
 
     auto timed_prospect = time_diff(start_prospect, time());
@@ -536,8 +145,7 @@ void prospect_genome(vector<CasProfile*>& profiles, std::filesystem::path genome
 
 void run(vector<CasProfile*>& profiles)
 {
-    // interest "GCA_002139875.1_ASM213987v1_genomic.fna"
-    unordered_set<string> interest {  };
+    unordered_set<string> interest {};
     ui limiter = 1;
     ui track = 0;
     for (const auto& entry : std::filesystem::directory_iterator(Config::path_genome))
@@ -553,132 +161,6 @@ void run(vector<CasProfile*>& profiles)
             break;
         }
     }
-}
-
-struct Hit
-{
-    CasProfile* profile;
-    ui hit_count;
-};
-
-// void hmm_db_experiment()
-// {
-//     vector<string> hmm_files = get_all_hmm_files();
-
-//     std::filesystem::path path_prodigal_proteins = "/home/ben/crispr/prospector-util/my.proteins.faa";
-
-//     map<string, string> proteins = Util::parse_fasta(path_prodigal_proteins, false);
-
-//     map<string, vector<Hit*>> protein_id_to_hits;
-
-//     for (auto & [identifier, sequence] : proteins)
-//     {
-// 		sequence.erase(remove(sequence.begin(), sequence.end(), '*'), sequence.end());
-//     }
-
-//     for (auto & [identifier, sequence] : proteins)
-//     {
-//         fmt::print("{}\n", identifier);
-//         for (string& hmm_file : hmm_files)F
-//         {
-//             bool positive = singleton_hammer(sequence, hmm_file);
-//             if (positive) {
-//                 fmt::print("got a positive on {}\n", sequence);
-//             }
-//         }
-//     }
-
-// }
-
-bool claim_validation(string& protein_sequence, string cas_claim)
-{
-    vector<string> hmm_files = get_hmm_files(cas_claim);
-    fmt::print("executing {} hmm files\n", hmm_files.size());
-    for (string hmm_file : hmm_files)
-    {
-        if (singleton_hammer(protein_sequence, hmm_file))
-        {
-            return true;
-        }
-    }
-    return false;
-}
-
-
-string hit_assessment(Hit* hit, string& protein_sequence)
-{
-    string cas_claim = CasProfileUtil::domain_table_fetch(hit->profile->identifier);
-    bool validated = claim_validation(protein_sequence, cas_claim);
-    return fmt::format("{} {} {} {}\n", hit->profile->identifier, cas_claim, hit->hit_count, validated);
-    
-}
-
-void analyze_prodigal_proteins(vector<CasProfile*>& profiles)
-{
-    auto start_prodigal = time();
-
-    std::filesystem::path path_prodigal_proteins = "/home/ben/crispr/prospector-util/my.proteins.faa";
-
-    map<string, string> proteins = Util::parse_fasta(path_prodigal_proteins, false);
-
-    map<string, vector<Hit*>> protein_id_to_hits;
-
-    for (auto & [identifier, sequence] : proteins)
-    {
-		sequence.erase(remove(sequence.begin(), sequence.end(), '*'), sequence.end());
-
-        auto kmers = Util::kmerize(sequence, 6);
-        auto kmers_encoded = Util::encode_amino_kmers(kmers, 6);
-
-        vector<Hit*> hits;
-
-        for (signed long p = 0; p < profiles.size(); p++)
-        {
-            CasProfile* profile = profiles[p];
-            // vector<ull> index;
-            ull count = 0;
-            for (ull i = 0; i < kmers_encoded.size(); i++)
-            {
-                bool contains = profile->hash_table.contains(kmers_encoded[i]);
-                if (contains)
-                    count++;
-                    // index.push_back(i);
-            }
-
-            Hit* hit = new Hit;
-            hit->profile = profile;
-            // hit->hit_count = index.size();
-            hit->hit_count = count;
-
-            hits.push_back(hit);
-        }
-
-        // sort hits
-        Util::sort(hits, [](Hit* a, Hit* b) { return a->hit_count > b->hit_count; });
-
-        // store hits
-        protein_id_to_hits[identifier] = hits;
-    }
-
-    start_prodigal = time(start_prodigal, "hit counts");
-
-    std::ofstream outtie("outtie.txt");
-
-    for (auto const& [identifier, hits] : protein_id_to_hits)
-    {
-        string protein_sequence = proteins[identifier];
-        outtie << fmt::format("{}\n", identifier);
-        outtie << hit_assessment(hits[0], protein_sequence);
-        outtie << hit_assessment(hits[1], protein_sequence);
-        outtie << hit_assessment(hits[2], protein_sequence);
-        outtie << "\n\n";
-    }
-
-    start_prodigal = time(start_prodigal, "hmmer");
-
-    outtie.close();
-
-    start_prodigal = time(start_prodigal, "full prodigal analysis");
 }
 
 int main(int argc, char *argv[])

--- a/src/prospector.cu
+++ b/src/prospector.cu
@@ -11,7 +11,6 @@
 #include <chrono>
 #include <stdio.h>
 #include "time_util.h"
-#include <string>
 
 
 #ifdef __CUDACC__
@@ -31,7 +30,6 @@
 #define GRID 32
 #define BLOCK 256
 
-const int difference = ((int) 'a') - ((int) 'A');
 
 cudaError_t checkCudaAlways(cudaError_t result)
 {
@@ -94,7 +92,7 @@ __global__ void compute_encoding(const char* genome, kmer* encoding, ull genome_
 Prospector::Encoding Prospector::get_genome_encoding(const char* genome, ull genome_size)
 {
 
-    Prospector::Encoding encoding{};
+    Prospector::Encoding encoding;
 
     cudaError er;
     
@@ -130,15 +128,16 @@ __device__ uc difference_gpu(const ui& _a, const ui& _b)
     return __popc(comp);
 }
 
-__global__ void compute_qmap_small(const ui* encoding, const ui encoding_size, uc* qmap) {
+__global__ void compute_qmap_small(const ui* encoding, const ui encoding_size, uc* qmap)
+{
     const ui thread_id = blockIdx.x * blockDim.x + threadIdx.x;
     const ui stride = blockDim.x * gridDim.x;
 
-    for (ui query = thread_id;
-         query < encoding_size - 200; query += stride) // TODO: replace 200 with MAP_SIZE or parameter map_size
+    for (ui query = thread_id; query < encoding_size - 200; query += stride) // TODO: replace 200 with MAP_SIZE or parameter map_size
     {
         ui query_enc = encoding[query];
-        for (ui i = 0; i < Prospector::map_size_small; i++) {
+        for (ui i = 0; i < Prospector::map_size_small; i++)
+        {
             ui t = encoding[query + Prospector::k_start + Prospector::spacer_skip + i];
             qmap[(query * Prospector::map_size_small) + i] = difference_gpu(query_enc, t);
         }

--- a/src/prospector.cu
+++ b/src/prospector.cu
@@ -11,6 +11,7 @@
 #include <chrono>
 #include <stdio.h>
 #include "time_util.h"
+#include <string>
 
 
 #ifdef __CUDACC__
@@ -30,6 +31,7 @@
 #define GRID 32
 #define BLOCK 256
 
+const int difference = ((int) 'a') - ((int) 'A');
 
 cudaError_t checkCudaAlways(cudaError_t result)
 {
@@ -92,7 +94,7 @@ __global__ void compute_encoding(const char* genome, kmer* encoding, ull genome_
 Prospector::Encoding Prospector::get_genome_encoding(const char* genome, ull genome_size)
 {
 
-    Prospector::Encoding encoding;
+    Prospector::Encoding encoding{};
 
     cudaError er;
     
@@ -128,16 +130,15 @@ __device__ uc difference_gpu(const ui& _a, const ui& _b)
     return __popc(comp);
 }
 
-__global__ void compute_qmap_small(const ui* encoding, const ui encoding_size, uc* qmap)
-{
+__global__ void compute_qmap_small(const ui* encoding, const ui encoding_size, uc* qmap) {
     const ui thread_id = blockIdx.x * blockDim.x + threadIdx.x;
     const ui stride = blockDim.x * gridDim.x;
 
-    for (ui query = thread_id; query < encoding_size - 200; query += stride) // TODO: replace 200 with MAP_SIZE or parameter map_size
+    for (ui query = thread_id;
+         query < encoding_size - 200; query += stride) // TODO: replace 200 with MAP_SIZE or parameter map_size
     {
         ui query_enc = encoding[query];
-        for (ui i = 0; i < Prospector::map_size_small; i++)
-        {
+        for (ui i = 0; i < Prospector::map_size_small; i++) {
             ui t = encoding[query + Prospector::k_start + Prospector::spacer_skip + i];
             qmap[(query * Prospector::map_size_small) + i] = difference_gpu(query_enc, t);
         }

--- a/src/unused/experiments.cpp
+++ b/src/unused/experiments.cpp
@@ -1,0 +1,3 @@
+//
+// Created by zach on 2/08/22.
+//

--- a/src/unused/experiments.cpp
+++ b/src/unused/experiments.cpp
@@ -1,3 +1,446 @@
 //
 // Created by zach on 2/08/22.
 //
+
+// // hardcoded against cas1 for now
+// vector<ui> hammer(vector<Fragment*> fragments) {
+
+//     // runtime:
+//     // - write candidate sequences to file
+//     // - system call of hmmscan
+//     // - parse results
+//     // - make decisions based on results
+
+//     vector<string> seqs;
+//     for (Fragment* fragment : fragments) {
+//         seqs.push_back(fragment->protein_sequence);
+//     }
+
+//     string fasta = Util::seqs_to_fasta(seqs);
+
+//     // write candidate sequence to file
+//     std::ofstream out("/home/ben/crispr/hmm/candidates_cas1.txt");
+//     out << fasta;
+//     out.close();
+
+//     // system call of hmmscan
+//     string call = "hmmscan --tblout tbloutty.txt /home/ben/crispr/hmm/Cas_Cas1.hmm /home/ben/crispr/hmm/candidates_cas1.txt > /dev/null";
+//     system(call.c_str());
+
+//     // parse tblout
+//     std::ifstream infile("tbloutty.txt");
+//     string line;
+//     vector<ui> acceptable_indices;
+
+//     while (std::getline(infile, line))
+//     {
+//         // fmt::print("line: {}\n", line);
+//         if (line.starts_with("#"))
+//             continue;
+
+//         vector<string> parse_result = Util::parse(line, " ");
+//         string query_name = parse_result[2];
+//         double score = std::stod(parse_result[5]);
+//         fmt::print("{} {}\n", query_name, score);
+//         acceptable_indices.push_back(std::stoi(query_name));
+//     }
+
+//     for (ui ting : acceptable_indices)
+//     {
+//         fmt::print("{}\n", ting);
+//     }
+
+//     return acceptable_indices;
+// }
+
+// vector<Fragment*> acceptable_indices_filter_methodology(vector<Fragment*> raw_fragments)
+// {
+//     // perform an analysis here of the fragments (either here or multifragments, not sure yet, but let's focus on proof of concept first)
+//     // let's focus just on cas1 for now
+//     vector<ui> acceptable_indices = hammer(raw_fragments);
+
+//     fmt::print("fasta enumeration of raw fragments:\n");
+//     for (ui i = 0; i < raw_fragments.size(); i++) {
+//         fmt::print("{}\n", i);
+//     }
+
+//     fmt::print("we now have acceptable indices\n");
+//     for (ui index : acceptable_indices) {
+//         fmt::print("{}\n", index);
+//     }
+
+//     vector<Fragment*> fragments;
+//     for (ui i = 0; i < raw_fragments.size(); i++) {
+//         if (Util::contains(acceptable_indices, i))
+//             fragments.push_back(raw_fragments[i]);
+//     }
+
+//     return fragments;
+// }
+
+
+
+//map<string, System*> system_map;
+//for (Fragment* f : fragments)
+//{
+//    if (!f->is_gene())
+//    {
+//        continue;
+//    }
+
+//    string id = f->reference_crispr->identifier_string();
+//    if (system_map.contains(id))
+//    {
+//        system_map[id]->fragments.push_back(f);
+//        continue;
+//    }
+
+//    System* system = new System;
+//    system->crispr = f->reference_crispr;
+//    system->fragments.push_back(f);
+//    system_map[id] = system;
+//}
+
+//vector<System*> systems;
+
+//for (map<string, System*>::iterator i = system_map.begin(); i != system_map.end(); i++)
+//{
+//    systems.push_back(i->second);
+//}
+
+//for (System* s : systems)
+//{
+//    s->type = resolve_type(s->fragments);
+//}
+
+//std::sort(systems.begin(), systems.end(), [](System* a, System* b) {return a->get_start() - b->get_start(); });
+//for (System* s : systems)
+//out_gene << s->to_string();
+
+
+//std::map<string, std::set<string>> load_type_table(std::filesystem::path path)
+//{
+//    std::map<string, std::set<string>> type_table;
+//
+//    std::ifstream table(path);
+//
+//    if (!table)
+//    {
+//        throw runtime_error(path.string());
+//    }
+//
+//    string line;
+//    while (getline(table, line))
+//    {
+//        auto split = Util::parse(line, "\t");
+//        auto type = split[0];
+//        auto required = split[1];
+//        auto additional_any = split[2];
+//
+//        std::set<string> genes;
+//
+//        for (string gene : Util::parse(, ","))
+//            genes.insert(gene);
+//
+//        type_table[links] = genes;
+//    }
+//}
+
+//string resolve_type(vector<Fragment*> fragments)
+//{
+//    return "N";
+//    for (Fragment* f : fragments)
+//    {
+//        string r = CasProfileUtil::domain_table_fetch(f->reference_profile->identifier);
+//        for (const auto& [a, b] : type_table)
+//            if (b.contains(r))
+//                return a;
+//    }
+//    return "N";
+//}
+
+//vector<string> get_all_hmm_files()
+//{
+//    vector<string> paths;
+//
+//    // step 1: iterate over the dir:
+//    std::filesystem::path directory = "/home/ben/crispr/prospector-data/bin_hmm_makarova";
+//
+//    // does the split[0] of the stem match the cas_type in a case insensitive way?
+//    for (const auto& entry : std::filesystem::directory_iterator(directory))
+//    {
+//        string filename = entry.path().filename().string();
+//        vector<string> extensions = Util::parse(filename, ".");
+//        string last_extension = extensions[extensions.size()-1];
+//
+//        if (last_extension != "hmm")
+//            continue;
+//
+//        string cas_type_of_file = Util::parse(filename, "_")[0];
+//        paths.push_back(entry.path().string());
+//    }
+//    return paths;
+//}
+//
+//vector<string> get_hmm_files(string cas_type)
+//{
+//    vector<string> paths;
+//
+//    // step 1: iterate over the dir:
+//    std::filesystem::path directory = "/home/ben/crispr/prospector-data/bin_hmm_makarova";
+//
+//    // does the split[0] of the stem match the cas_type in a case insensitive way?
+//    for (const auto& entry : std::filesystem::directory_iterator(directory))
+//    {
+//        string filename = entry.path().filename().string();
+//        vector<string> extensions = Util::parse(filename, ".");
+//        string last_extension = extensions[extensions.size()-1];
+//
+//        if (last_extension != "hmm")
+//            continue;
+//
+//        string cas_type_of_file = Util::parse(filename, "_")[0];
+//        if (boost::iequals(cas_type_of_file, cas_type))
+//        {
+//            paths.push_back(entry.path().string());
+//        }
+//    }
+//    return paths;
+//}
+//
+//string get_hmm_file(string hmm_identifier)
+//{
+//    fmt::print("seeking HMM file with identifier: {}\n", hmm_identifier);
+//    return fmt::format("/home/ben/crispr/hmm/hmm_files/{}.HMM", hmm_identifier);
+//}
+//
+//bool have_hmm_file(string hmm_file)
+//{
+//    bool exists = std::filesystem::exists(hmm_file);
+//    if (!exists)
+//    {
+//        fmt::print("does NOT exist: {}\n", hmm_file);
+//    }
+//    return exists;
+//}
+
+//bool singleton_hammer(string& singleton_seq, string hmm_file)
+//{
+//    if (!have_hmm_file(hmm_file))
+//    {
+//        throw new exception();
+//    }
+//
+//
+//    vector<string> singleton_vec;
+//    singleton_vec.push_back(singleton_seq);
+//    string fasta = Util::seqs_to_fasta(singleton_vec);
+//
+//    std::filesystem::path temp_fasta_file = "/media/ben/temp/crispr_lfs/temp_fasta.txt";
+//
+//    // write candidate sequence to file
+//    std::ofstream out(temp_fasta_file.string());
+//    out << fasta;
+//    out.close();
+//
+//    string call = fmt::format("hmmscan --cpu 10 --tblout tbloutty.txt {} {} > /dev/null", hmm_file, temp_fasta_file.string());
+//    system(call.c_str());
+//
+//    // parse tblout
+//    std::ifstream infile("tbloutty.txt");
+//    string line;
+//    vector<ui> acceptable_indices;
+//
+//    while (std::getline(infile, line))
+//    {
+//        // fmt::print("line: {}\n", line);
+//        if (line.starts_with("#"))
+//            continue;
+//
+//        vector<string> parse_result = Util::parse(line, " ");
+//        string query_name = parse_result[2];
+//        double score = std::stod(parse_result[5]);
+//        fmt::print("{} {}\n", query_name, score);
+//        acceptable_indices.push_back(std::stoi(query_name));
+//    }
+//
+//    // return true;
+//    assert(acceptable_indices.size() <= 1);
+//    return acceptable_indices.size() > 0;
+//}
+
+// bool singleton_hammer(Fragment* fragment) {
+//     string hmm_file;
+
+//     // attempt an exact match
+//     hmm_file = get_hmm_file(fragment->reference_profile->identifier);
+//     if (!have_hmm_file(hmm_file)) {
+//         // exact match could be found, so this is probably like a COG profile. In which case we get the profile's domain and then we find a suitable HMM for that domain.
+//     }
+
+//     return singleton_hammer(fragment->protein_sequence, hmm_file);
+// }
+
+//bool multimatch_hammer(Fragment* fragment) {
+//    string cas_type_of_fragment = CasProfileUtil::domain_table_fetch(fragment->reference_profile->identifier);
+//    vector<string> hmm_files = get_hmm_files(cas_type_of_fragment);
+//
+//    for (string hmm_file : hmm_files) {
+//        if (singleton_hammer(fragment->protein_sequence, hmm_file)) {
+//            return true;
+//        }
+//    }
+//    return false;
+//}
+
+// vector<Fragment*> individuated_singleton_methodology(vector<Fragment*> raw_fragments) {
+//     vector<Fragment*> fragments;
+//     for (Fragment* fragment : raw_fragments) {
+//         if (singleton_hammer(fragment)) {
+//             fragments.push_back(fragment);
+//         }
+//         else {
+//             fmt::print("rejecting {} {} {} {} on the basis of hammer\n", fragment->reference_profile->identifier, CasProfileUtil::domain_table_fetch(fragment->reference_profile->identifier), fragment->expanded_genome_begin, fragment->expanded_genome_final);
+//         }
+//     }
+//     return fragments;
+// }
+
+//vector<Fragment*> multimatch_singleton_methodology(vector<Fragment*> raw_fragments) {
+//    vector<Fragment*> fragments;
+//    for (Fragment* fragment : raw_fragments) {
+//        if (multimatch_hammer(fragment)) {
+//            fragments.push_back(fragment);
+//        }
+//        else {
+//            fmt::print("rejecting {} {} {} {} on the basis of hammer\n", fragment->reference_profile->identifier, CasProfileUtil::domain_table_fetch(fragment->reference_profile->identifier), fragment->expanded_genome_begin, fragment->expanded_genome_final);
+//        }
+//    }
+//    return fragments;
+//}
+
+// void hmm_db_experiment()
+// {
+//     vector<string> hmm_files = get_all_hmm_files();
+
+//     std::filesystem::path path_prodigal_proteins = "/home/ben/crispr/prospector-util/my.proteins.faa";
+
+//     map<string, string> proteins = Util::parse_fasta(path_prodigal_proteins, false);
+
+//     map<string, vector<Hit*>> protein_id_to_hits;
+
+//     for (auto & [identifier, sequence] : proteins)
+//     {
+// 		sequence.erase(remove(sequence.begin(), sequence.end(), '*'), sequence.end());
+//     }
+
+//     for (auto & [identifier, sequence] : proteins)
+//     {
+//         fmt::print("{}\n", identifier);
+//         for (string& hmm_file : hmm_files)F
+//         {
+//             bool positive = singleton_hammer(sequence, hmm_file);
+//             if (positive) {
+//                 fmt::print("got a positive on {}\n", sequence);
+//             }
+//         }
+//     }
+
+// }
+
+//struct Hit
+//{
+//    CasProfile* profile;
+//    ui hit_count;
+//};
+
+//bool claim_validation(string& protein_sequence, string cas_claim)
+//{
+//    vector<string> hmm_files = get_hmm_files(cas_claim);
+//    fmt::print("executing {} hmm files\n", hmm_files.size());
+//    for (string hmm_file : hmm_files)
+//    {
+//        if (singleton_hammer(protein_sequence, hmm_file))
+//        {
+//            return true;
+//        }
+//    }
+//    return false;
+//}
+//
+//
+//string hit_assessment(Hit* hit, string& protein_sequence)
+//{
+//    string cas_claim = CasProfileUtil::domain_table_fetch(hit->profile->identifier);
+//    bool validated = claim_validation(protein_sequence, cas_claim);
+//    return fmt::format("{} {} {} {}\n", hit->profile->identifier, cas_claim, hit->hit_count, validated);
+//
+//}
+//
+//void analyze_prodigal_proteins(vector<CasProfile*>& profiles)
+//{
+//    auto start_prodigal = time();
+//
+//    std::filesystem::path path_prodigal_proteins = "/home/ben/crispr/prospector-util/my.proteins.faa";
+//
+//    map<string, string> proteins = Util::parse_fasta(path_prodigal_proteins, false);
+//
+//    map<string, vector<Hit*>> protein_id_to_hits;
+//
+//    for (auto & [identifier, sequence] : proteins)
+//    {
+//        sequence.erase(remove(sequence.begin(), sequence.end(), '*'), sequence.end());
+//
+//        auto kmers = Util::kmerize(sequence, 6);
+//        auto kmers_encoded = Util::encode_amino_kmers(kmers, 6);
+//
+//        vector<Hit*> hits;
+//
+//        for (signed long p = 0; p < profiles.size(); p++)
+//        {
+//            CasProfile* profile = profiles[p];
+//            // vector<ull> index;
+//            ull count = 0;
+//            for (ull i = 0; i < kmers_encoded.size(); i++)
+//            {
+//                bool contains = profile->hash_table.contains(kmers_encoded[i]);
+//                if (contains)
+//                    count++;
+//                // index.push_back(i);
+//            }
+//
+//            Hit* hit = new Hit;
+//            hit->profile = profile;
+//            // hit->hit_count = index.size();
+//            hit->hit_count = count;
+//
+//            hits.push_back(hit);
+//        }
+//
+//        // sort hits
+//        Util::sort(hits, [](Hit* a, Hit* b) { return a->hit_count > b->hit_count; });
+//
+//        // store hits
+//        protein_id_to_hits[identifier] = hits;
+//    }
+//
+//    start_prodigal = time(start_prodigal, "hit counts");
+//
+//    std::ofstream outtie("outtie.txt");
+//
+//    for (auto const& [identifier, hits] : protein_id_to_hits)
+//    {
+//        string protein_sequence = proteins[identifier];
+//        outtie << fmt::format("{}\n", identifier);
+//        outtie << hit_assessment(hits[0], protein_sequence);
+//        outtie << hit_assessment(hits[1], protein_sequence);
+//        outtie << hit_assessment(hits[2], protein_sequence);
+//        outtie << "\n\n";
+//    }
+//
+//    start_prodigal = time(start_prodigal, "hmmer");
+//
+//    outtie.close();
+//
+//    start_prodigal = time(start_prodigal, "full prodigal analysis");
+//}

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -320,15 +320,10 @@ vector<kmer> Util::encode_amino_kmers(vector<string> kmers, ull k)
 	return encoded;
 }
 
-
-
-//map<string, string> Util::load_genomes(string dir)
-//{
-//	auto start = time();
-//    map<string, string> genomes;
-//    for (const auto& entry : filesystem::directory_iterator(dir))
-//        genomes[entry.path().stem().string()] = (load_genome(entry.path().string()));
-//	start = time(start, "genome load");
-//	return genomes;
-//}
-//
+void Util::assert_file(std::filesystem::path path)
+{
+    if (!std::filesystem::exists(path))
+    {
+        throw std::filesystem::filesystem_error("Could not locate filepath: ", path, error_code());
+    }
+}


### PR DESCRIPTION
# Summary

A variety of changes to:
- No longer rely on absolute file paths
- Remove redundant code that makes it hard to navigate codebase without scrolling past lines and lines of unused functions
- Move some type declarations to header files
- Make the CMake build step a bit easier on different machines (I did try to auto-detect gpu archs, but it wasn't working reliably. Might have to set as an ENV var instead.)

Please leave comments for anything you think should be kept around or changed!