### PR TITLE
Feat/benchmarking parasability

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,7 +40,9 @@ set_property(TARGET exec PROPERTY CXX_STANDARD 20)
 find_package(OpenMP)
 if(OpenMP_CXX_FOUND)
     SET(OPENMP OpenMP::OpenMP_CXX)
+    set (CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${OpenMP_C_FLAGS}")
+    set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${OpenMP_CXX_FLAGS}")
+    set (CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} ${OpenMP_EXE_LINKER_FLAGS}")
 endif()
-
 
 target_link_libraries(exec util prospector ${Boost_LIBRARIES} ${OPENMP})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,6 +36,7 @@ set_property(TARGET prospector PROPERTY CXX_STANDARD 17)
 
 add_executable(exec "src/main.cpp" include/config.h include/system.h)
 set_property(TARGET exec PROPERTY CXX_STANDARD 20)
+set_target_properties(exec PROPERTIES OUTPUT_NAME "prospector")
 
 find_package(OpenMP)
 if(OpenMP_CXX_FOUND)

--- a/include/system.h
+++ b/include/system.h
@@ -52,17 +52,19 @@ struct System
         return last->get_final();
     }
 
-    string to_string_summary()
+    string to_string_summary(string& genome_id)
     {
         std::ostringstream out;
+        out << '>' << genome_id << endl;
         for (Locus* l : this->loci)
             out << l->to_string_summary() << endl;
         return out.str();
     }
 
-    string to_string_debug()
+    string to_string_debug(string& genome_id)
     {
         std::ostringstream out;
+        out << '>' << genome_id << endl;
         for (Locus* l : this->loci)
             out << l->to_string_debug() << endl;
         return out.str();

--- a/include/util.h
+++ b/include/util.h
@@ -5,8 +5,9 @@
 
 namespace Util
 {
+    using GenomeIdSequenceMap = map<string, string>;
 
-	static const string stop = "Z";
+    static const string stop = "Z";
     static const char stop_c = 'Z';
 
 	std::vector<std::string> parse(std::string str, std::string delim);
@@ -212,8 +213,8 @@ namespace Util
 		string str = fmt::format("sort {} items", iterable.size());
 	}
 
-	map<string, string> load_genome(std::filesystem::path);
-	map<string, string> parse_fasta(string, bool);
+	map<string, string> load_genome(const std::filesystem::path&);
+	map<string, string> parse_fasta(const string&, bool);
 	//string parse_fasta_single(string);
 
 	char complement(char nuc);

--- a/include/util.h
+++ b/include/util.h
@@ -212,7 +212,7 @@ namespace Util
 		string str = fmt::format("sort {} items", iterable.size());
 	}
 
-	string load_genome(std::filesystem::path);
+	map<string, string> load_genome(std::filesystem::path);
 	map<string, string> parse_fasta(string, bool);
 	//string parse_fasta_single(string);
 

--- a/src/array_discovery.cpp
+++ b/src/array_discovery.cpp
@@ -145,9 +145,6 @@ vector<Crispr*> Array::get_crisprs(string& genome)
     CrisprUtil::cache_crispr_information(genome, crisprs);
     start = time(start, "cache");
 
-    // Debug::crispr_print(crisprs, genome, 1011480, 1011656 + 100);
-    // std::exit(1);
-
     crisprs = Util::filter(crisprs, [](Crispr* c) { return c->overall_heuristic >= -10; });
     Util::sort(crisprs, CrisprUtil::heuristic_greater);
     crisprs = CrisprUtil::get_domain_best(crisprs);

--- a/src/cas.cpp
+++ b/src/cas.cpp
@@ -1,3 +1,5 @@
+#pragma clang diagnostic push
+#pragma ide diagnostic ignored "openmp-use-default-none"
 #include "cas.h"
 #include "config.h"
 
@@ -164,7 +166,6 @@ bool fragment_contains(const Fragment* a, const Fragment* b)
 
 vector<Fragment*> Cas::cas(vector<CasProfile*>& profiles, vector<Translation*>& translations, string& genome)
 {
-
     vector<Fragment*> fragments;
 
     #pragma omp parallel for
@@ -449,3 +450,5 @@ vector<Translation*> Cas::crispr_proximal_translations(const string& genome, vec
 
 
 
+
+#pragma clang diagnostic pop

--- a/src/crispr.cpp
+++ b/src/crispr.cpp
@@ -392,6 +392,5 @@ string Crispr::to_string_debug()
 
 string Crispr::to_string_summary()
 {
-	//return fmt::format("{}\t{}\t{}\t{}\t{}h\n", start, end, "?", "CRISPR", overall_heuristic);
 	return fmt::format("{}\t{}\t{}\t{}\t{}", genome_start, genome_final, "?", "CRISPR", overall_heuristic);
 }

--- a/src/debug.cpp
+++ b/src/debug.cpp
@@ -2,7 +2,7 @@
 
 void Debug::visualize_map(string genome_path)
 {
-    map<string, string> genome = Util::load_genome(genome_path);
+    Util::GenomeIdSequenceMap genome = Util::load_genome(genome_path);
 
     for (auto const& [genom_id, genome_sequence] : genome) {
         Prospector::Encoding encoding = Prospector::get_genome_encoding(genome_sequence.c_str(), genome.size());
@@ -76,7 +76,7 @@ vector<Crispr*> Debug::crispr_filter(vector<Crispr*> crisprs, ull start, ull fin
 
 void Debug::genome_substr(const string& genome_path, ull genome_start, ull genome_final)
 {
-    map<string, string> genome = Util::load_genome(genome_path);
+    Util::GenomeIdSequenceMap genome = Util::load_genome(genome_path);
     for (auto const& [genome_id, genome_sequence] : genome) {
         fmt::print("{}\n",genome_sequence.substr(genome_start, genome_final - genome_start));
     }
@@ -104,7 +104,7 @@ string Debug::translation_test(const string& genome, ull genome_start, ull genom
 
 void Debug::translation_print(const string& genome_path, ull genome_start, ull genome_final, bool pos, ull debug_aminos)
 {
-    map<string, string> genome = Util::load_genome(genome_path);
+    Util::GenomeIdSequenceMap genome = Util::load_genome(genome_path);
     for (auto const& [genome_id, genome_sequence] : genome) {
         string translation = Debug::translation_test(genome_sequence, genome_start, genome_final, pos, debug_aminos);
         fmt::print("debug: {}..{} {}\n", genome_start, genome_final, translation);
@@ -128,7 +128,7 @@ void Debug::cas_detect(std::filesystem::path genome_path, ull genome_start, ull 
     string filename = "cas_detection_report.txt";
     std::ofstream file(filename.c_str());
 
-    map<string, string> genome = Util::load_genome(genome_path);
+    Util::GenomeIdSequenceMap genome = Util::load_genome(genome_path);
 
     for (auto const& [genome_id, genome_sequence] : genome) {
         vector<Translation *> triframe = Cas::get_triframe(genome_sequence, genome_start, genome_final,
@@ -167,9 +167,6 @@ void Debug::cas_detect(std::filesystem::path genome_path, ull genome_start, ull 
             file << fmt::format("---------------------\n");
         }
     }
-
-
-
 }
 
 void Debug::crispr_print(vector<Crispr*> crisprs, const string& genome, ull start, ull final)
@@ -189,9 +186,6 @@ void Debug::crispr_print(vector<Crispr*> crisprs, const string& genome, ull star
     exit(0);
 }
 
-
-
-
 void Debug::cartograph_interpreter(std::filesystem::path path, std::filesystem::path genome_dir)
 {
     std::ifstream in(path);
@@ -201,7 +195,7 @@ void Debug::cartograph_interpreter(std::filesystem::path path, std::filesystem::
         
     string line;
     string genome_accession = "";
-    map<string,string> genome;
+    Util::GenomeIdSequenceMap genome;
 
     string interpretation_path = "cartograph_interpretation.txt";
     std::ofstream interpretation(interpretation_path.c_str());

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -97,7 +97,7 @@ void prospect_genome(vector<CasProfile*>& profiles, std::filesystem::path genome
     std::ofstream out_gene(results_path / "out_gene.txt");
     std::ofstream out_gene_debug(results_path / "out_gene_debug.txt");
 
-    auto genome_map = Util::load_genome(genome_path);
+    Util::GenomeIdSequenceMap genome_map = Util::load_genome(genome_path);
 
     for (auto const& [genome_id, genome_sequence] : genome_map)
     {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -97,43 +97,53 @@ void prospect_genome(vector<CasProfile*>& profiles, std::filesystem::path genome
     std::ofstream out_gene(results_path / "out_gene.txt");
     std::ofstream out_gene_debug(results_path / "out_gene_debug.txt");
 
-    string genome = Util::load_genome(genome_path);
+    auto genome_map = Util::load_genome(genome_path);
 
-    vector<Translation*> translations;
-    vector<Crispr*> crisprs;
-
-    if (Config::cas_only) {
-        translations = Cas::get_sixframe(genome, 0, genome.length()-1);
-    } else {
-        crisprs = Array::get_crisprs(genome);
-        translations = Config::crispr_proximal_search ? Cas::crispr_proximal_translations(genome, crisprs) : Cas::get_sixframe(genome, 0, genome.length()-1);
-    }
-
-    vector<Fragment*> fragments = Cas::cas(profiles, translations, genome);
-    vector<MultiFragment*> multifragments = gen_multifragments(fragments);
-  
-    std::vector<Locus*> loci;
-
-    for (Crispr* c : crisprs)
-        loci.push_back(c);
-
-    for (MultiFragment* f : multifragments)
-        loci.push_back(f);
-
-    std::sort(loci.begin(), loci.end(), [](Locus* a, Locus* b) { return a->get_start() < b->get_start(); });
-
-    vector<System*> systems = gen_systems(loci);
-
-    for (System* system : systems)
+    for (auto const& [genome_id, genome_sequence] : genome_map)
     {
-        out_gene << system->to_string_summary();
-        out_gene_debug << system->to_string_debug() << endl;
-    }
+        vector<Translation*> translations;
+        vector<Crispr*> crisprs;
 
-    for (Crispr* c : crisprs) delete c;
-    for (Translation* t : translations) delete t;
-    for (MultiFragment* m : multifragments) delete m;
-    for (System* s : systems) delete s;
+        if (Config::cas_only) {
+            fmt::print("Acquiring translations for {}...\n", genome_id);
+            translations = Cas::get_sixframe(genome_sequence, 0, genome_sequence.length()-1);
+        } else {
+            fmt::print("Acquiring CRISPRs & translations for {}...\n", genome_id);
+            crisprs = Array::get_crisprs(const_cast<string &>(genome_sequence));
+            translations = Config::crispr_proximal_search ?
+                    Cas::crispr_proximal_translations(genome_sequence, crisprs) :
+                    Cas::get_sixframe(genome_sequence, 0, genome_sequence.length()-1);
+        }
+
+        fmt::print("Detecting Cas genes for {}...\n", genome_id);
+        vector<Fragment*> fragments = Cas::cas(profiles, translations, const_cast<string &>(genome_sequence));
+        vector<MultiFragment*> multifragments = gen_multifragments(fragments);
+
+        fmt::print("Collating results for {}...\n", genome_id);
+        std::vector<Locus*> loci;
+
+        for (Crispr* c : crisprs)
+            loci.push_back(c);
+
+        for (MultiFragment* f : multifragments)
+            loci.push_back(f);
+
+        std::sort(loci.begin(), loci.end(), [](Locus* a, Locus* b) { return a->get_start() < b->get_start(); });
+
+        vector<System*> systems = gen_systems(loci);
+
+        fmt::print("Writing results for {} to file...\n", genome_id);
+        for (System* system : systems)
+        {
+            out_gene << system->to_string_summary(const_cast<string &>(genome_id));
+            out_gene_debug << system->to_string_debug(const_cast<string &>(genome_id)) << endl;
+        }
+
+        for (Crispr* c : crisprs) delete c;
+        for (Translation* t : translations) delete t;
+        for (MultiFragment* m : multifragments) delete m;
+        for (System* s : systems) delete s;
+    }
 
     auto timed_prospect = time_diff(start_prospect, time());
 

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -3,9 +3,6 @@
 
 std::vector<std::string> Util::parse(std::string str, std::string delim)
 {
-	//std::string s = "scott>=tiger>=mushroom";
-	//std::string delimiter = ">=";
-
 	std::vector < std::string> tokens;
 
 	size_t pos = 0;
@@ -27,14 +24,10 @@ std::vector<std::string> Util::parse(std::string str, std::string delim)
 	}
 	tokens.push_back(str);
 	return tokens;
-	//std::cout << s << std::endl;
 }
 
 std::vector<std::string> Util::parse_exact(std::string str, std::string delim)
 {
-	//std::string s = "scott>=tiger>=mushroom";
-	//std::string delimiter = ">=";
-
 	std::vector < std::string> tokens;
 
 	size_t pos = 0;
@@ -49,7 +42,6 @@ std::vector<std::string> Util::parse_exact(std::string str, std::string delim)
 	}
 	tokens.push_back(str);
 	return tokens;
-	//std::cout << s << std::endl;
 }
 
 
@@ -60,7 +52,6 @@ ui Util::difference_cpu(const ui& _a, const ui& _b)
 	ui oddBits = _xor & 0x5555555555555555ull;
 	ui comp = (evenBits >> 1) | oddBits;
 	return __builtin_popcount(comp);
-	//return std::popcount(comp);
 }
 
 string Util::translate_domain(const string& domain)
@@ -98,84 +89,23 @@ bool Util::any_overlap(ull a_start, ull a_final, ull b_start, ull b_final)
 }
 
 
-map<string, string> Util::load_genome(std::filesystem::path path)
+Util::GenomeIdSequenceMap Util::load_genome(const std::filesystem::path& path)
 {
-
-	fmt::print("reading {}\n", path.string());
+	fmt::print("Reading {}...\n", path.string());
 
 	ifstream input(path);
 	if (!input.good())
 	{
-		throw runtime_error("input not good!");
+		throw runtime_error("Input file is not good!");
 	}
 
-	auto fasta = parse_fasta(path.string(), true);
-    return fasta;
-
-	// string seq = "";
-	string max_name = "";
-	int max_length = 0;
-	for (auto const& [name, sequence] : fasta)
-	{
-		if (sequence.length() > max_length)
-		{
-			max_length = sequence.length();
-			max_name = name;
-		}
-	}
-
-	// fmt::print("genome seq count is: {}\n", i);
-//	return fasta[max_name];
-	// return seq;
-
-	auto check_line = [](string& line) {
-		assert(line.find(' ') == string::npos);
-		assert(line.find("\r") == string::npos);
-	};
-
-	string line;
-	string name;
-
-	
-	string content;
-	// getline(input, line);
-	// assert(line.starts_with('>'));
-	// name = line.substr(1);
-	
-	// while (true)
-	// {
-		// getline(input, line);
-
-		// if (line.empty() || line[0] == '>')
-		// {
-			//content.erase(std::remove(content.begin(), content.end(), 'N'), content.end());
-			//content.erase(std::remove(content.begin(), content.end(), 'R'), content.end());
-			//content.erase(std::remove(content.begin(), content.end(), 'Y'), content.end());
-			//content.erase(std::remove(content.begin(), content.end(), 'K'), content.end());
-			//content.erase(std::remove(content.begin(), content.end(), 'W'), content.end());
-			//content.erase(std::remove(content.begin(), content.end(), 'M'), content.end());
-			//content.erase(std::remove(content.begin(), content.end(), 'S'), content.end());
-			
-			
-			
-			// content.erase(std::remove_if(content.begin(), content.end(), [](char c) { return !(c == 'A' || c == 'C' || c == 'G' || c == 'T'); }), content.end());
-			// return content;
-		// }
-
-		// check_line(line);
-		// content += line;
-		// fmt::print("hello world\n");
-	// }
-
-	assert(false);
+    return parse_fasta(path.string(), true);
 }
 
 // dna = true for dna
 // dna = false for amino
-map<string, string> Util::parse_fasta(string file_path, bool dna)
+Util::GenomeIdSequenceMap Util::parse_fasta(const string& file_path, bool dna)
 {
-	// printf("reading %s... ", file_path.c_str());
-	// auto start = time();
 	ifstream input(file_path);
 	if (!input.good())
 	{
@@ -200,6 +130,9 @@ map<string, string> Util::parse_fasta(string file_path, bool dna)
 			}
 			if (!line.empty())
 			{
+                // Genome name formatted like '>GENOME_ID <genome_sequence>'.
+                // Find first occurrence of ' ' and remove it by subtracting 1.
+                // Start search at position 1 to remove '>' from the name.
 				name = line.substr(1, line.find(' ') - 1);
 			}
 			content.clear();
@@ -229,8 +162,6 @@ map<string, string> Util::parse_fasta(string file_path, bool dna)
 
 		seqs[name] = content;
 	}
-
-    fmt::print("Found genome: {}\n", name);
 
 	return seqs;
 }

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -98,7 +98,7 @@ bool Util::any_overlap(ull a_start, ull a_final, ull b_start, ull b_final)
 }
 
 
-string Util::load_genome(std::filesystem::path path)
+map<string, string> Util::load_genome(std::filesystem::path path)
 {
 
 	fmt::print("reading {}\n", path.string());
@@ -109,8 +109,8 @@ string Util::load_genome(std::filesystem::path path)
 		throw runtime_error("input not good!");
 	}
 
-
 	auto fasta = parse_fasta(path.string(), true);
+    return fasta;
 
 	// string seq = "";
 	string max_name = "";
@@ -125,7 +125,7 @@ string Util::load_genome(std::filesystem::path path)
 	}
 
 	// fmt::print("genome seq count is: {}\n", i);
-	return fasta[max_name];
+//	return fasta[max_name];
 	// return seq;
 
 	auto check_line = [](string& line) {
@@ -182,7 +182,6 @@ map<string, string> Util::parse_fasta(string file_path, bool dna)
 		throw runtime_error("input not good!");
 	}
 
-
 	map<string, string> seqs;
 	string line, name, content;
 	while (getline(input, line))
@@ -201,7 +200,7 @@ map<string, string> Util::parse_fasta(string file_path, bool dna)
 			}
 			if (!line.empty())
 			{
-				name = line.substr(1);
+				name = line.substr(1, line.find(' ') - 1);
 			}
 			content.clear();
 		}
@@ -231,7 +230,8 @@ map<string, string> Util::parse_fasta(string file_path, bool dna)
 		seqs[name] = content;
 	}
 
-	// done(start);
+    fmt::print("Found genome: {}\n", name);
+
 	return seqs;
 }
 


### PR DESCRIPTION
# Summary

In order to properly analyse Prospector's performance, a variety of small changes had to be made.

- Output files now contain a line starting with `>`, followed by the genome's ID, before each section of results (this allows me to analyse which predictions are for which genome).
- When a file contained multiple genomes, only the longest genome would be selected from the file. I have changed the genome loading code to instead return a map of genome IDs to genome sequences, so Prospector can analyse every genome in a fasta file.
- Consequently, all genome analysis is now performed in a for-loop over this map structure (`Util::GenomeIdSequenceMap`).
- Built executable is called `prospector` instead of `exec`
- Added more config to the CMake file to enable OpenMP
- Also removed more comments/unused code
